### PR TITLE
Use pre-compiled Go tip

### DIFF
--- a/.github/workflows/all.yml
+++ b/.github/workflows/all.yml
@@ -62,7 +62,7 @@ jobs:
           go-version: ${{ matrix.go-version }}
       - name: Download Go tip
         if: matrix.go-version == 'tip'
-        uses: robinraju/release-downloader@v1.8
+        uses: robinraju/release-downloader@efa4cd07bd0195e6cc65e9e30c251b49ce4d3e51 # v1.8
         with:
           repository: "grafana/gotip"
           tag: "${{ matrix.platform }}"

--- a/.github/workflows/all.yml
+++ b/.github/workflows/all.yml
@@ -60,17 +60,17 @@ jobs:
         uses: actions/setup-go@v3
         with:
           go-version: ${{ matrix.go-version }}
-      - name: Install Go stable
+      - name: Download Go tip
         if: matrix.go-version == 'tip'
-        uses: actions/setup-go@v3
+        uses: robinraju/release-downloader@v1.8
         with:
-          go-version: 1.x
+          repository: "grafana/gotip"
+          tag: "${{ matrix.platform }}"
+          fileName: go.zip
       - name: Install Go tip
-        shell: bash
         if: matrix.go-version == 'tip'
         run: |
-          go install golang.org/dl/gotip@latest
-          gotip download
+          unzip go.zip -d $HOME/sdk
           echo "GOROOT=$HOME/sdk/gotip" >> "$GITHUB_ENV"
           echo "GOPATH=$HOME/go" >> "$GITHUB_ENV"
           echo "$HOME/go/bin" >> "$GITHUB_PATH"

--- a/.github/workflows/all.yml
+++ b/.github/workflows/all.yml
@@ -60,11 +60,6 @@ jobs:
         uses: actions/setup-go@v5
         with:
           go-version: ${{ matrix.go-version }}
-      - name: Install Go stable
-        if: matrix.go-version == 'tip'
-        uses: actions/setup-go@v5
-        with:
-          go-version: 1.x
       - name: Download Go tip
         if: matrix.go-version == 'tip'
         uses: robinraju/release-downloader@v1.8

--- a/.github/workflows/all.yml
+++ b/.github/workflows/all.yml
@@ -31,9 +31,9 @@ jobs:
           go-version: 1.21.x
       - name: Check dependencies
         run: |
-            go version
-            test -z "$(go mod tidy  && git status --porcelain)"
-            go mod verify
+          go version
+          test -z "$(go mod tidy  && git status --porcelain)"
+          go mod verify
 
   lint:
     runs-on: ubuntu-latest
@@ -49,8 +49,8 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        go-version: [1.20.x, 1.21.x, tip]
-        platform: [ubuntu-latest, windows-latest]
+        go-version: [ 1.20.x, 1.21.x, tip ]
+        platform: [ ubuntu-latest, windows-latest ]
     runs-on: ${{ matrix.platform }}
     steps:
       - name: Checkout code
@@ -62,11 +62,10 @@ jobs:
           go-version: ${{ matrix.go-version }}
       - name: Download Go tip
         if: matrix.go-version == 'tip'
-        uses: robinraju/release-downloader@efa4cd07bd0195e6cc65e9e30c251b49ce4d3e51 # v1.8
-        with:
-          repository: "grafana/gotip"
-          tag: "${{ matrix.platform }}"
-          fileName: go.zip
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          gh release download ${{ matrix.platform }} --repo grafana/gotip --pattern 'go.zip'
       - name: Install Go tip
         if: matrix.go-version == 'tip'
         run: |

--- a/.github/workflows/all.yml
+++ b/.github/workflows/all.yml
@@ -22,11 +22,11 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout code
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
           fetch-depth: 0
       - name: Install Go
-        uses: actions/setup-go@v3
+        uses: actions/setup-go@v5
         with:
           go-version: 1.21.x
       - name: Check dependencies
@@ -39,7 +39,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout code
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
           fetch-depth: 0
       - name: Run k6's golangci-lint CI
@@ -54,12 +54,17 @@ jobs:
     runs-on: ${{ matrix.platform }}
     steps:
       - name: Checkout code
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
       - name: Install Go ${{ matrix.go-version }}
         if: matrix.go-version != 'tip'
-        uses: actions/setup-go@v3
+        uses: actions/setup-go@v5
         with:
           go-version: ${{ matrix.go-version }}
+      - name: Install Go stable
+        if: matrix.go-version == 'tip'
+        uses: actions/setup-go@v5
+        with:
+          go-version: 1.x
       - name: Download Go tip
         if: matrix.go-version == 'tip'
         uses: robinraju/release-downloader@v1.8
@@ -85,9 +90,9 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout code
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
       - name: Install Go
-        uses: actions/setup-go@v3
+        uses: actions/setup-go@v5
         with:
           go-version: 1.21.x
       - name: Check build


### PR DESCRIPTION
Similar to https://github.com/grafana/k6/pull/3555, and more specifically like https://github.com/grafana/xk6-kerberos/pull/27.

In fact, we could even close the latter PR (specific to `xk6-kerberos`) if we get this one merged (and get these benefits in all the repositories that are using this shared configuration).