### PR TITLE
Bump latest version for go to 1.22

### DIFF
--- a/.github/workflows/all.yml
+++ b/.github/workflows/all.yml
@@ -28,7 +28,7 @@ jobs:
       - name: Install Go
         uses: actions/setup-go@v5
         with:
-          go-version: 1.21.x
+          go-version: 1.22.x
       - name: Check dependencies
         run: |
           go version
@@ -49,7 +49,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        go-version: [ 1.20.x, 1.21.x, tip ]
+        go-version: [ 1.21.x, 1.22.x, tip ]
         platform: [ ubuntu-latest, windows-latest ]
     runs-on: ${{ matrix.platform }}
     steps:
@@ -88,7 +88,7 @@ jobs:
       - name: Install Go
         uses: actions/setup-go@v5
         with:
-          go-version: 1.21.x
+          go-version: 1.22.x
       - name: Check build
         run: |
           go version


### PR DESCRIPTION
### What

It bumps the latest version to go 1.22 and the previous to 1.21.

### Why

k6 is now based on go 1.22 better to test the rest of the ecosystem against the same version. 