### PR TITLE
Fix(renovate): override minimumReleaseAge for github-actions digests

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -1,0 +1,4 @@
+{
+    "$schema": "https://docs.renovatebot.com/renovate-schema.json",
+    "prCreation": "not-pending"
+}

--- a/renovate.json
+++ b/renovate.json
@@ -1,4 +1,10 @@
 {
     "$schema": "https://docs.renovatebot.com/renovate-schema.json",
-    "prCreation": "not-pending"
+    "packageRules": [
+        {
+            "description": "Disable minimumReleaseAge for GitHub Actions (digest updates don't have reliable release timestamps)",
+            "matchManagers": ["github-actions"],
+            "minimumReleaseAge": null
+        }
+    ]
 }


### PR DESCRIPTION
Disable minimumReleaseAge for GitHub Actions to prevent digest updates from getting stuck with pending stability-days 
checks. Digest updates don't have reliable release timestamps, similar to Docker/GHCR images as in :
https://github.com/grafana/sm-renovate/commit/793f880bca65cbadeb6afe88bcdac2c4a64c0c99

