### PR TITLE
Add renovate config to avoid early pr creation

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -1,0 +1,5 @@
+{
+  "$schema": "https://docs.renovatebot.com/renovate-schema.json",
+  "prCreation": "not-pending",
+  "rebaseWhen": "conflicted"
+}


### PR DESCRIPTION
Follow up to https://github.com/grafana/k6-ci/pull/18
As part of https://github.com/grafana/deployment_tools/issues/438042

Adding renovate config to test Renovate adhering to minimum release age with ci checks against the repository