### PR TITLE
Always check for latest go so we do not fail when we bump

### DIFF
--- a/.github/workflows/all.yml
+++ b/.github/workflows/all.yml
@@ -44,6 +44,7 @@ jobs:
         with:
           go-version: 1.26.x
           cache: false # against cache-poisoning
+          check-latest: true
       - name: Check dependencies
         run: |
           go version
@@ -76,6 +77,7 @@ jobs:
         with:
           go-version: ${{ matrix.go-version }}
           cache: false # against cache-poisoning
+          check-latest: true
       - name: Download Go tip
         if: matrix.go-version == 'tip'
         env:
@@ -107,6 +109,7 @@ jobs:
         with:
           go-version: 1.26.x
           cache: false # against cache-poisoning
+          check-latest: true
       - name: Check build
         run: |
           go version


### PR DESCRIPTION
Otherwise we are currently getting 1.25.7 when the project already depends on 1.25.8 and fails 