### PR TITLE
templates: flatten Makefile to .golangci.yml at repo root

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,10 +26,12 @@ Drop a `.golangci.patch` at your repo root — a unified diff against `.golangci
 Workflow for editing the patch:
 
 ```sh
-make lint                # materializes build/lint/.golangci.yml (the effective config)
-$EDITOR build/lint/.golangci.yml
+make lint                # materializes .golangci.yml at the repo root (effective config)
+$EDITOR .golangci.yml
 make update-lint-patch   # rewrites .golangci.patch from the edits
 ```
+
+Both `.golangci-base.yml` (cached download) and `.golangci.yml` (assembled) should be gitignored.
 
 Constraints:
 
@@ -44,10 +46,11 @@ Constraints:
 |---|---|
 | `lint` | Download base, apply patch, run golangci-lint at the pinned version. |
 | `update-lint-patch` | Regenerate `.golangci.patch` from the locally edited `$(LINT_FINAL)`. |
-| `clean-lint` | Remove `$(LINT_DIR)`. |
+| `clean-lint` | Remove `$(LINT_BASE)` and `$(LINT_FINAL)`. |
 
 Override variables on the command line (or in your top-level Makefile):
 
 - `WORKFLOW` — file to read the k6-ci ref from. Default `.github/workflows/k6-ci.yml`.
-- `LINT_DIR` — where the assembled config lives. Default `build/lint`.
+- `LINT_BASE` — cached download path. Default `.golangci-base.yml`.
+- `LINT_FINAL` — assembled config path. Default `.golangci.yml`.
 - `LINT_PATCH` — patch file path. Default `.golangci.patch`.

--- a/templates/Makefile
+++ b/templates/Makefile
@@ -1,27 +1,28 @@
 # Run the k6-ci golangci-lint config locally. See grafana/k6-ci/README.md.
 # Targets: lint, update-lint-patch, clean-lint.
-# Overrides: WORKFLOW, LINT_DIR, LINT_PATCH.
+# Overrides: WORKFLOW, LINT_BASE, LINT_FINAL, LINT_PATCH.
+#
+# Produces two gitignored files at the repo root:
+#   .golangci-base.yml  cached download from grafana/k6-ci (only re-fetched
+#                       when WORKFLOW changes)
+#   .golangci.yml       effective config = base + LINT_PATCH (if present)
 
 WORKFLOW   ?= .github/workflows/k6-ci.yml
 K6_CI_REF  := $(shell grep -oE 'grafana/k6-ci/[^@[:space:]]+@[A-Za-z0-9._/-]+' $(WORKFLOW) | head -n1 | cut -d@ -f2)
 BASE_URL   := https://raw.githubusercontent.com/grafana/k6-ci/$(K6_CI_REF)/.golangci.yml
 
-LINT_DIR   ?= build/lint
-LINT_BASE  := $(LINT_DIR)/.golangci-base.yml
-LINT_FINAL := $(LINT_DIR)/.golangci.yml
+LINT_BASE  ?= .golangci-base.yml
+LINT_FINAL ?= .golangci.yml
 LINT_PATCH ?= .golangci.patch
 
-$(LINT_DIR):
-	mkdir -p $@
-
-$(LINT_BASE): $(WORKFLOW) | $(LINT_DIR)
+$(LINT_BASE): $(WORKFLOW)
 	curl -fsSL $(BASE_URL) -o $@
 
 $(LINT_FINAL): $(LINT_BASE) $(wildcard $(LINT_PATCH))
 	cp $(LINT_BASE) $@
 	@if [ -f $(LINT_PATCH) ]; then \
 	  echo "Applying $(LINT_PATCH)"; \
-	  git apply --directory=$(LINT_DIR) $(LINT_PATCH); \
+	  git apply $(LINT_PATCH); \
 	fi
 
 .PHONY: lint
@@ -39,4 +40,4 @@ update-lint-patch: $(LINT_BASE)
 
 .PHONY: clean-lint
 clean-lint:
-	rm -rf $(LINT_DIR)
+	rm -f $(LINT_BASE) $(LINT_FINAL)


### PR DESCRIPTION
## What

`templates/Makefile` no longer creates a `build/lint/` subdirectory. Instead, the cached base and the assembled effective config live as two gitignored dotfiles at the consumer repo root:

- `.golangci-base.yml` — cached download from this repo (refreshed only when the workflow file with the pinned ref changes).
- `.golangci.yml` — `base + .golangci.patch` (or just `base` if no patch).

Caching behavior is unchanged. `git apply` runs without `--directory=` since both files are at cwd. `make clean-lint` is now `rm -f \$(LINT_BASE) \$(LINT_FINAL)` rather than `rm -rf \$(LINT_DIR)`. README updated; `LINT_DIR` replaced by `LINT_BASE` / `LINT_FINAL` overrides.

## Why

Creating a new top-level `build/` dir in every consumer just to hold one ~3KB yaml plus its applied counterpart is unnecessary scaffolding. Two dotfiles at the root are simpler and easier to gitignore explicitly.

## Compatibility

This only changes what new adopters copy. Existing consumers that already copied `templates/Makefile` are unaffected until they re-copy.

🤖 Generated with [Claude Code](https://claude.com/claude-code)