### PR TITLE
ci: also check vendor/ sync in dependencies job

### DIFF
--- a/.github/workflows/all.yml
+++ b/.github/workflows/all.yml
@@ -68,8 +68,19 @@ jobs:
       - name: Check dependencies
         run: |
           go version
-          test -z "$(go mod tidy  && git status --porcelain)"
+          go mod tidy
+          # If the caller's repo vendors dependencies, also verify that
+          # `vendor/` is in sync with go.mod. The presence of a top-level
+          # `vendor/` directory is the trigger; no input needed.
+          if [ -d vendor ]; then
+            go mod vendor
+          fi
           go mod verify
+          if [ -n "$(git status --porcelain)" ]; then
+            echo "Working tree dirty after go mod tidy/vendor:"
+            git status --porcelain
+            exit 1
+          fi
 
   lint:
     runs-on: ubuntu-latest


### PR DESCRIPTION
## What

Two changes to the `dependencies` job in `all.yml`:

1. **Auto-detect `vendor/`**: when the caller's repo has a top-level `vendor/` directory, additionally run `go mod vendor` and assert a clean working tree afterward. Triggered by directory presence — no new input. Non-vendoring consumers (the majority) see no change.

2. **Fix a latent bug**: the old `test -z "\$(go mod tidy && git status --porcelain)"` masked errors. bash's `set -e` does not propagate failures out of command substitution, so a broken `go mod tidy` would produce empty stdout and `test -z` would silently pass. Run each command as a top-level statement so `set -e` catches non-zero exits, and check the dirty tree separately with a helpful message on failure.

## Why

Lets vendoring consumers stop maintaining their own `deps` job that mirrors this one with an extra `go mod vendor`.

The error-masking fix is independently worth having — a misbehaving `go mod tidy` in any consumer would have been invisible until now.

## Compatibility

Backward-compatible. Non-vendoring consumers behave identically. Vendoring consumers get the additional check for free.

🤖 Generated with [Claude Code](https://claude.com/claude-code)