### PR TITLE
ci: exclude revive var-naming for generic package names

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -103,6 +103,12 @@ linters:
       - linters:
           - forbidigo
         text: use of `os\.(SyscallError|Signal|Interrupt)` forbidden
+      - linters:
+          - revive
+        text: avoid meaningless package names
+      - linters:
+          - revive
+        text: avoid package names that conflict with Go standard library
     paths:
       - third_party$
       - builtin$


### PR DESCRIPTION
## What

Add two \`revive\` text-match exclusions to the canonical \`.golangci.yml\`:

- \`avoid meaningless package names\`
- \`avoid package names that conflict with Go standard library\`

## Why

These suppressions previously lived in grafana/k6's \`.golangci.yml\`. Repos that consumed k6's config (now migrating to k6-ci) inherited them implicitly. Without them, common package names like \`api\`, \`types\`, \`version\`, \`util\` fail lint — and downstream maintainers consistently end up patching them out anyway.

Hoisting these into the canonical config is the simpler outcome: one source of truth, no per-repo \`.golangci.patch\` carrying the same two lines.

## Compatibility

Strictly relaxing: any consumer that was previously passing lint will continue to. Any consumer that wanted the strict behavior could re-add it in their own \`.golangci.patch\` if they really want.

🤖 Generated with [Claude Code](https://claude.com/claude-code)