### PR TITLE
ci: split deps + lint out of all.yml into composite actions

### DIFF
--- a/.github/actions/deps/action.yml
+++ b/.github/actions/deps/action.yml
@@ -1,0 +1,26 @@
+name: k6-deps-check
+description: |
+  Run `go mod tidy` (and `go mod vendor`, if a `vendor/` directory is
+  present), then `go mod verify`. Fail if the working tree is dirty after.
+
+  Caller responsibilities (before invoking this action): `actions/checkout`,
+  `actions/setup-go`, plus any private-module auth (e.g. ssh-agent +
+  `git config --global url.<...>.insteadOf <...>`).
+
+runs:
+  using: composite
+  steps:
+    - name: Check dependencies
+      shell: bash
+      run: |
+        go version
+        go mod tidy
+        if [ -d vendor ]; then
+          go mod vendor
+        fi
+        go mod verify
+        if [ -n "$(git status --porcelain)" ]; then
+          echo "Working tree dirty after go mod tidy/vendor:"
+          git status --porcelain
+          exit 1
+        fi

--- a/.github/actions/lint/action.yml
+++ b/.github/actions/lint/action.yml
@@ -1,0 +1,65 @@
+name: golangci-lint-k6
+description: |
+  Download the canonical k6 golangci-lint config from grafana/k6-ci at a
+  specified ref, apply an optional `.golangci.patch` from the caller's
+  workspace, then run golangci-lint at the version pinned on line 1 of the
+  config.
+
+  Caller responsibilities (before invoking this action): `actions/checkout`
+  and `actions/setup-go`, plus any credential setup needed to lint private
+  code (the action itself doesn't touch the network beyond the config download).
+
+inputs:
+  ref:
+    required: false
+    default: ""
+    description: |
+      Ref of grafana/k6-ci to fetch `.golangci.yml` from. Resolution order:
+        1. This input, if non-empty.
+        2. `github.action_ref`, if the action was invoked as
+           `grafana/k6-ci/.github/actions/lint@<ref>` (direct caller).
+        3. In-tree `${GITHUB_WORKSPACE}/.golangci.yml`, if the file exists
+           (k6-ci's own CI on a PR).
+        4. `main`.
+
+runs:
+  using: composite
+  steps:
+    - name: Build golangci config
+      shell: bash
+      env:
+        REF_INPUT: ${{ inputs.ref }}
+        ACTION_REF: ${{ github.action_ref }}
+      run: |
+        cfg_dir="${GITHUB_WORKSPACE}/.k6-ci-lint"
+        cfg="${cfg_dir}/.golangci.yml"
+        mkdir -p "${cfg_dir}"
+
+        ref="${REF_INPUT:-${ACTION_REF}}"
+        if [ -n "${ref}" ]; then
+          rules_url="https://raw.githubusercontent.com/grafana/k6-ci/${ref}/.golangci.yml"
+          echo "Downloading '${rules_url}' ..."
+          curl --silent --show-error --fail --no-location "${rules_url}" --output "${cfg}"
+        elif [ -f "${GITHUB_WORKSPACE}/.golangci.yml" ]; then
+          echo "Using in-tree .golangci.yml from caller workspace"
+          cp "${GITHUB_WORKSPACE}/.golangci.yml" "${cfg}"
+        else
+          echo "Downloading .golangci.yml from grafana/k6-ci@main (fallback)"
+          curl --silent --show-error --fail --no-location \
+            "https://raw.githubusercontent.com/grafana/k6-ci/main/.golangci.yml" --output "${cfg}"
+        fi
+
+        patch_file="${GITHUB_WORKSPACE}/.golangci.patch"
+        if [ -f "${patch_file}" ]; then
+          echo "Applying '${patch_file}' ..."
+          git -C "${GITHUB_WORKSPACE}" apply --directory=.k6-ci-lint "${patch_file}"
+        fi
+
+        echo "version=$(head -n 1 "${cfg}" | tr -d '# ')" >> "${GITHUB_OUTPUT}"
+        echo "config=${cfg}" >> "${GITHUB_OUTPUT}"
+      id: cfg
+    - name: golangci-lint
+      uses: golangci/golangci-lint-action@1e7e51e771db61008b38414a730f564565cf7c20 # v9.2.0
+      with:
+        version: ${{ steps.cfg.outputs.version }}
+        args: "--config=${{ steps.cfg.outputs.config }}"

--- a/.github/workflows/all.yml
+++ b/.github/workflows/all.yml
@@ -65,22 +65,12 @@ jobs:
           go-version: 1.26.x
           cache: false # against cache-poisoning
           check-latest: true
-      - name: Check dependencies
-        run: |
-          go version
-          go mod tidy
-          # If the caller's repo vendors dependencies, also verify that
-          # `vendor/` is in sync with go.mod. The presence of a top-level
-          # `vendor/` directory is the trigger; no input needed.
-          if [ -d vendor ]; then
-            go mod vendor
-          fi
-          go mod verify
-          if [ -n "$(git status --porcelain)" ]; then
-            echo "Working tree dirty after go mod tidy/vendor:"
-            git status --porcelain
-            exit 1
-          fi
+      # Pinned to main rather than `./.github/actions/deps` because the
+      # latter resolves to the caller's workspace under workflow_call —
+      # not k6-ci's. PRs to k6-ci that modify this action need to be
+      # exercised via workflow_dispatch or a downstream caller pinned to
+      # the PR's SHA, not via all.yml's own PR checks.
+      - uses: grafana/k6-ci/.github/actions/deps@main
 
   lint:
     runs-on: ubuntu-latest
@@ -96,42 +86,9 @@ jobs:
           go-version: 1.26.x
           cache: false # against cache-poisoning
           check-latest: true
-      - name: Build golangci config
-        env:
-          # Empty for non-workflow_call triggers (push, pull_request, etc.).
-          # When empty we treat this as k6-ci's own CI and use the in-tree
-          # .golangci.yml from the checkout. When set, an external caller is
-          # invoking us via workflow_call and we curl the config at their
-          # pinned ref.
-          K6_CI_REF: ${{ inputs.k6-ci-ref }}
-        run: |
-          cfg_dir="${GITHUB_WORKSPACE}/.k6-ci-lint"
-          cfg="${cfg_dir}/.golangci.yml"
-          mkdir -p "${cfg_dir}"
-
-          if [ -n "${K6_CI_REF}" ]; then
-            rules_url="https://raw.githubusercontent.com/grafana/k6-ci/${K6_CI_REF}/.golangci.yml"
-            echo "Downloading '${rules_url}' ..."
-            curl --silent --show-error --fail --no-location "${rules_url}" --output "${cfg}"
-          else
-            echo "Using in-tree .golangci.yml (k6-ci self-CI)"
-            cp "${GITHUB_WORKSPACE}/.golangci.yml" "${cfg}"
-          fi
-
-          patch_file="${GITHUB_WORKSPACE}/.golangci.patch"
-          if [ -f "${patch_file}" ]; then
-            echo "Applying '${patch_file}' ..."
-            git -C "${GITHUB_WORKSPACE}" apply --directory=.k6-ci-lint "${patch_file}"
-          fi
-
-          echo "version=$(head -n 1 "${cfg}" | tr -d '# ')" >> "${GITHUB_OUTPUT}"
-          echo "config=${cfg}" >> "${GITHUB_OUTPUT}"
-        id: cfg
-      - name: golangci-lint
-        uses: golangci/golangci-lint-action@1e7e51e771db61008b38414a730f564565cf7c20 # v9.2.0
+      - uses: grafana/k6-ci/.github/actions/lint@main
         with:
-          version: ${{ steps.cfg.outputs.version }}
-          args: "--config=${{ steps.cfg.outputs.config }}"
+          ref: ${{ inputs.k6-ci-ref }}
 
   test-go-versions:
     if: ${{ !inputs.skip-tests }}

--- a/.github/workflows/self-test.yml
+++ b/.github/workflows/self-test.yml
@@ -1,0 +1,54 @@
+# Exercises the composite actions under .github/actions/ from the local
+# checkout (via `./` paths) on every push/PR to k6-ci, so action changes
+# are validated before merge.
+#
+# all.yml uses `grafana/k6-ci/.github/actions/...@main` and therefore runs
+# the merged version, not the PR's. This workflow fills that gap.
+# See AGENTS.md ("Self-CI gap on action changes").
+
+name: Self test
+on:
+  push:
+    branches: [main]
+  pull_request:
+
+defaults:
+  run:
+    shell: bash
+
+permissions:
+  contents: read
+
+jobs:
+  deps:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+        with:
+          fetch-depth: 0
+      - name: Install Go
+        uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6
+        with:
+          go-version: 1.26.x
+          cache: false # against cache-poisoning
+          check-latest: true
+      - uses: ./.github/actions/deps
+
+  lint:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+        with:
+          persist-credentials: false
+          fetch-depth: 0
+      - name: Install Go
+        uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6
+        with:
+          go-version: 1.26.x
+          cache: false # against cache-poisoning
+          check-latest: true
+      # No `ref` input — the action falls back to the in-tree .golangci.yml,
+      # which on this PR is exactly the file we want to lint with.
+      - uses: ./.github/actions/lint

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -6,7 +6,7 @@ Reusable CI workflows and a composite GitHub Action that k6 extensions call via 
 
 The single reusable workflow is the repo's product. Downstream k6 extensions reference it and inherit dependency verification, linting, multi-version/multi-platform testing, and xk6 build checks. The test module exists only to validate the CI pipeline itself; it implements the k6 module interface but exports nothing.
 
-Data flows outward: extensions call in, and the workflow pulls external artifacts at runtime. The canonical `.golangci.yml` lives here; the composite action at `.github/actions/lint/` downloads it at the caller's pinned ref and optionally applies a `.golangci.patch` from the caller's workspace. The `extension-build-testing` job installs `xk6` from master, not a pinned version.
+Data flows outward: extensions call in, and the workflow pulls external artifacts at runtime. The canonical `.golangci.yml` lives here; the composite action at `.github/actions/lint/` downloads it at the caller's pinned ref and optionally applies a `.golangci.patch` from the caller's workspace. The `.github/actions/deps/` composite action handles the `go mod tidy` + optional vendor sync + `go mod verify` check; callers compose it themselves when they need to wire up private-module credentials first. The `extension-build-testing` job installs `xk6` from master, not a pinned version.
 
 Go tip is sourced from `grafana/gotip` GitHub releases. The release tag matches the runner platform name (e.g., `ubuntu-latest`).
 
@@ -18,3 +18,4 @@ Go tip is sourced from `grafana/gotip` GitHub releases. The release tag matches 
 - Line 1 of `.golangci.yml` is the golangci-lint version pin (`# vX.Y.Z`). Tooling reads it; do not remove the comment.
 - The test file is intentionally named `mudule_test.go`. Do not rename it.
 - The workflow's `skip-extension-testing` input is compared with `!= true` (not `!= 'true'`). GitHub coerces booleans for `workflow_dispatch` but not always for `workflow_call`; callers must pass a real boolean.
+- **Self-CI gap on action changes**: `all.yml` references `.github/actions/{deps,lint}` as `grafana/k6-ci/...@main`, not `./`, because `./` resolves to the caller's workspace under workflow_call. Consequence: a PR to k6-ci that modifies one of those actions runs all.yml against the *merged* version of the action, not the PR's. The companion workflow `self-test.yml` uses `./` paths on push/PR to k6-ci and exercises the PR's version. Both should pass before merging an action change.


### PR DESCRIPTION
## What

Extract the inline `dependencies` and `lint` job logic from `.github/workflows/all.yml` into composite actions under `.github/actions/`:

- `.github/actions/deps/` — `go mod tidy` + optional vendor sync + `go mod verify` + clean-tree assert. Zero inputs.
- `.github/actions/lint/` — download `.golangci.yml` at a resolvable ref, apply optional `.golangci.patch` from the caller's workspace, run golangci-lint at the line-1 version. Single `ref` input; falls back to `github.action_ref` → in-tree file → `main`.

`all.yml` keeps the same scope; its `dependencies` and `lint` jobs are now thin: checkout + setup-go + a single `uses:` of the matching composite action.

Adds `.github/workflows/self-test.yml` which runs the two actions via `./` paths on push/PR to k6-ci, so action changes are exercised before merge (all.yml uses `grafana/k6-ci/...@main` and can't pick up the PR version itself — see AGENTS.md).

## Why

The reusable workflow is fine when a caller wants all the standard checks in one go. It's less useful when a caller needs to interleave its own setup steps before deps/lint runs, or to slot deps/lint into a job that already exists.

Exposing the same logic as composite actions lets callers compose freely: `actions/checkout` → caller's own setup → `grafana/k6-ci/.github/actions/deps@<ref>` → `grafana/k6-ci/.github/actions/lint@<ref>`. The reusable workflow stays the simple one-knob entry point for repos that don't need that flexibility.

## Files

- `+ .github/actions/deps/action.yml`
- `+ .github/actions/lint/action.yml`
- `+ .github/workflows/self-test.yml`
- `~ .github/workflows/all.yml` — `dependencies` and `lint` jobs reduced to single `uses:` each.
- `~ AGENTS.md` — describe the deps action; document the self-CI gap on action changes.

Net **+155 / −52**.

## Compatibility

Strictly additive for current \`all.yml\` consumers. The \`dependencies\` and \`lint\` jobs run the same logic, just routed through the new actions. No input changes. The existing \`k6-ci-ref\` input is plumbed through to the lint action's \`ref\` input.

## Follow-up

- Renovate alignment for the \`k6-ci-ref:\` input is being handled in grafana/grafana-renovate-config#90 — landing it makes the workflow_call SHA and the input stay in lockstep on Renovate PRs. Independent of this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)