### PR TITLE
ci(deps): print git diff when working tree is dirty

### DIFF
--- a/.github/actions/deps/action.yml
+++ b/.github/actions/deps/action.yml
@@ -22,5 +22,6 @@ runs:
         if [ -n "$(git status --porcelain)" ]; then
           echo "Working tree dirty after go mod tidy/vendor:"
           git status --porcelain
+          git --no-pager diff
           exit 1
         fi


### PR DESCRIPTION
## What

One-line addition to \`.github/actions/deps/action.yml\`: when the working tree is dirty after \`go mod tidy && go mod vendor\`, also print \`git --no-pager diff\` alongside the existing \`git status --porcelain\` output.

## Why

\`git status --porcelain\` shows that files changed but not what changed. The usual cause of a dirty tree here is a subtle \`go.mod\`/\`go.sum\` reshuffle when a downstream caller's Go toolchain produces a slightly different tidy output (e.g. promoting a transitive dep from indirect to direct). Seeing the diff in CI logs lets the maintainer fix it without re-running locally.

## Doubles as a smoke test for the actions-split architecture

This is the first PR after #38 (split deps + lint into composite actions) lands. The dual-workflow setup means:

- \`self-test.yml\` runs \`./.github/actions/deps\` — picks up this PR's version.
- \`all.yml\` runs \`grafana/k6-ci/.github/actions/deps@main\` — runs the merged \`main\` version.

Both should be green on the happy path (k6-ci's own tree stays clean after tidy). If anything's amiss with the split, this would surface.

🤖 Generated with [Claude Code](https://claude.com/claude-code)