### PR TITLE
chore: align go directive and toolchain to 1.25.0 / 1.25.11

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -2,6 +2,8 @@ module github.com/grafana/k6-ci
 
 go 1.25.0
 
+toolchain go1.25.11
+
 require go.k6.io/k6 v1.7.1
 
 require (


### PR DESCRIPTION
## Summary
Align `go.mod` to `go 1.25.0` and `toolchain go1.25.11` to match the k6-core baseline.

## Test plan
- [ ] `go mod tidy` is clean
- [ ] CI passes