### PR TITLE
Enable Renovate auto-merge for trusted reps

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -1,6 +1,7 @@
 {
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
   "extends": [
-    "github>grafana/grafana-renovate-config//presets/k6/k6-engine-base.json"
+    "github>grafana/grafana-renovate-config//presets/k6/k6-engine-base.json",
+    "github>grafana/grafana-renovate-config//presets/k6/k6-engine-automerge.json"
   ]
 }


### PR DESCRIPTION
## What?

Enables the k6 Renovate auto-merge approval flow, replicating the setup proven in [k6-pilot](https://github.com/grafana/k6-pilot).

- Extends `renovate.json` with [the shared preset](https://github.com/grafana/grafana-renovate-config/blob/main/presets/k6/k6-engine-automerge.json) for auto-merging trusted deps.

## Why?

To reduce the team's toll on Renovate PRs by 50%.

## Related PR(s)/Issue(s)

- grafana/k6-pilot#86
- grafana/k6-ci#44