### PR TITLE
Run the Renovate auto-approve sweep hourly

### DIFF
--- a/.github/workflows/auto-approve-renovate-cron.yml
+++ b/.github/workflows/auto-approve-renovate-cron.yml
@@ -1,0 +1,14 @@
+name: Auto-approve Renovate (cron)
+on:
+  schedule:
+    - cron: "1 * * * *"
+  workflow_dispatch:
+permissions:
+  contents: read
+  pull-requests: read
+  checks: read
+  statuses: read
+  id-token: write
+jobs:
+  approve:
+    uses: grafana/k6-ci/.github/workflows/auto-approve-renovate.yml@9477260e6838640d56c28aa95bcbf9a884ab21f3 # k6-ci#44 merge commit


### PR DESCRIPTION
## What?

Runs the Renovate auto-approve sweep hourly.

## Why?

- `auto-approve-renovate.yml` here is the shared reusable workflow; it only runs when a caller schedules it.
- The repo has the [automerge preset](https://github.com/grafana/grafana-renovate-config/blob/main/presets/k6/k6-engine-automerge.json), but nothing triggers the sweep, so its own Renovate PRs never get bot approvals.
- A thin scheduled caller closes the gap; other repos already run one.

## Related

- grafana/k6-pilot#86
